### PR TITLE
Added a WordPress example for the rest url in the connection configuration screen

### DIFF
--- a/views/form.php
+++ b/views/form.php
@@ -39,7 +39,8 @@
                     <td width="5%"/>
                     <td align="left">
                         <span><input id="url" name="url" type="text" size="15" value="<?php echo esc_attr($profile->url ?? ''); ?>" class="regular-text code"></span>
-                        <p class="description"><?php esc_html_e('E.g. https://my-civi.org/sites/all/modules/civicrm/extern/rest.php'); ?></p>
+                        <p class="description"><?php esc_html_e('E.g. https://my-civi.org/sites/all/modules/civicrm/extern/rest.php (Drupal)'); ?></p>
+                        <p class="description"><?php esc_html_e('or https://my-civi.org/wp-json/civicrm/v3/rest (WordPress)'); ?></p>
                     </td>
                 </tr>
 


### PR DESCRIPTION
This plugin is created for WordPress. The example on the connection configuration screen is for Drupal. This PR adds also an example for WordPress.

Before:

![before](https://user-images.githubusercontent.com/14834891/109020950-bce43880-76ba-11eb-94db-99009a3b7a0e.png)


After:

![after](https://user-images.githubusercontent.com/14834891/109020750-89091300-76ba-11eb-81c3-8c7d438fadf5.png)
