### PR TITLE
Validated DB addition

### DIFF
--- a/CMRF/Wordpress/Admin/AdminPage.php
+++ b/CMRF/Wordpress/Admin/AdminPage.php
@@ -171,6 +171,11 @@ class AdminPage {
       }
     }
 
+    if (empty($error) && empty($profile->validated)) {
+      // We don't have an error, so update the profile to show it is validated.
+      $wpdb->query("UPDATE {$wpdb->get_blog_prefix()}wpcivimrf_profile SET validated = 1 WHERE id = {$profile_id}");
+    }
+
     if ($show_message) {
       return $error ?
         '<div class="notice notice-error">' . __('Validation failed', 'wpcmrf') . ": " . $error . '</div>' :

--- a/wpcmrf.php
+++ b/wpcmrf.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Connector to CiviCRM with CiviMcRestFace
  * Description: Provides an API connector to a local or remote CiviCRM installation. This connector could be used by other plugins. Funded by Artfulrobot, CiviCoop, civiservice.de, Bundesverband Soziokultur e.V., Article 19
- * Version: 1.0.12
+ * Version: 1.0.13
  * Author: Rich Lott (Artfulrobot), Jaap Jansma (CiviCooP)
  * Plugin URI: https://github.com/CiviMRF/civimcrestface-wordpress
  * Text Domain: wpcmrf
@@ -26,8 +26,13 @@
 // All functions are Wordpress-specific.
 defined('ABSPATH') or die('No script kiddies please!');
 
-$wpcmrf_version = '1.0.12';
+$wpcmrf_version = '1.0.13';
 define('WPCMRF_PLUGIN_DIR', plugin_dir_path(__FILE__));
+
+/**
+ * Get parameter for upgrade error code
+ */
+define('GET_WPCMRF_ERROR_PARAM', 'wpcmrf-error');
 
 require_once(WPCMRF_PLUGIN_DIR . '/vendor/autoload.php');
 // @todo autoloader for this.
@@ -87,6 +92,49 @@ function wpcmrf_install( $network_wide ) {
   }
 }
 
+function wpcmrf_check_for_updates() {
+  global $wpdb;
+  global $wpcmrf_version;
+
+  $installed_version = get_option('wpcmrf_version');
+  if (is_multisite()) {
+    if ( is_plugin_active_for_network( $plugin_file_path ) ) {
+      foreach (get_sites(['fields' => 'ids']) as $blog_id) {
+        switch_to_blog($blog_id);
+        $installed_version = get_option('wpcmrf_version');
+        wpcmrf_process_updates($installed_version);
+        restore_current_blog();
+      }
+    }
+    else {
+      wpcmrf_process_updates($installed_version);
+    }
+  }
+  else {
+    wpcmrf_process_updates($installed_version);
+  }
+}
+add_action('plugins_loaded', 'wpcmrf_check_for_updates');
+
+function wpcmrf_process_updates($installed_version = null) {
+  global $wpcmrf_version;
+
+  if (empty($installed_version) || ($installed_version < $wpcmrf_version)) {
+    switch ($installed_version) {
+      case '1.0.12':
+        // Need to make sure the new `validated` column is added.
+        wpcmrf_install_into_current_blog();
+        break;
+      default:
+        // Process an updates prior to v1.0.13 as we now force in an update of the version.
+        // Need to make sure the new `validated` column is added.
+        wpcmrf_install_into_current_blog();
+        break;
+    }
+    update_option("wpcmrf_version", $wpcmrf_version, false);
+  }
+}
+
 function wpcmrf_install_into_current_blog() {
   global $wpdb;
   global $wpcmrf_version;
@@ -102,6 +150,7 @@ function wpcmrf_install_into_current_blog() {
       urlV4 varchar(255) DEFAULT '' NOT NULL,
       site_key varchar(255) DEFAULT '' NOT NULL,
       api_key varchar(255) DEFAULT '' NOT NULL,
+      validated bit DEFAULT 0 NOT NULL,
   PRIMARY KEY  (id)
   ) ENGINE = InnoDB $charset_collate;";
 
@@ -129,7 +178,7 @@ function wpcmrf_install_into_current_blog() {
 
   dbDelta($sql);
 
-  add_option("wpcmrf_version", $wpcmrf_version);
+  add_option("wpcmrf_version", $wpcmrf_version, false);
 }
 
 register_activation_hook(__FILE__, 'wpcmrf_install');

--- a/wpcmrf.php
+++ b/wpcmrf.php
@@ -124,14 +124,29 @@ function wpcmrf_process_updates($installed_version = null) {
       case '1.0.12':
         // Need to make sure the new `validated` column is added.
         wpcmrf_install_into_current_blog();
-        break;
-      default:
-        // Process an updates prior to v1.0.13 as we now force in an update of the version.
-        // Need to make sure the new `validated` column is added.
-        wpcmrf_install_into_current_blog();
+        // Attempt to revalidate existing profiles.
+        wpcmrf_revalidate_profiles();
         break;
     }
     update_option("wpcmrf_version", $wpcmrf_version, false);
+  }
+}
+
+/**
+ * Loops through all profiles where the `validated` column is false and attempts to revalidate them.
+ * Should only be called when upgrading versions prior to v1.0.13.
+ *
+ * @return void
+ */
+function wpcmrf_revalidate_profiles() {
+  global $wpdb;
+  require_once(WPCMRF_PLUGIN_DIR . '/CMRF/Wordpress/Admin/AdminPage.php');
+
+  $profiles = $wpdb->get_results("SELECT * FROM {$wpdb->get_blog_prefix()}wpcivimrf_profile");
+  foreach($profiles as $profile) {
+    if (empty($profile->validated)) {
+      \CMRF\Wordpress\Admin\AdminPage::validate($profile->id, false);
+    }
   }
 }
 

--- a/wpcmrf.php
+++ b/wpcmrf.php
@@ -98,7 +98,7 @@ function wpcmrf_check_for_updates() {
 
   $installed_version = get_option('wpcmrf_version');
   if (is_multisite()) {
-    if ( is_plugin_active_for_network( $plugin_file_path ) ) {
+    if ( is_plugin_active_for_network('connector-civicrm-mcrestface/wpcmrf.php') ) {
       foreach (get_sites(['fields' => 'ids']) as $blog_id) {
         switch_to_blog($blog_id);
         $installed_version = get_option('wpcmrf_version');


### PR DESCRIPTION
This is a PR for Issue #13.

This PR implements a new `validated` column for the profile table. On new installs, it will be added. For older installs, I have added a new function to check for previous versions and a way to process any DB updates or any other logic needed when the update doesn't just add/adjust code.

I had thought about pulling the profile table script out and making it a global variable so it could be used in both the activation function and then in the upgrade function. But since you are using the `dbDelta` function in the activation hook, it seemed logical to just call the same function for the upgrade. I am up for discussion on this as needed.

Lastly, this adds the DB column update into the AdminPage `validate` function. If the validation is successful, it will update the profile. We could add logic within the upgrade function as well to recheck all saved profiles and update as needed.